### PR TITLE
Add assertions for UI elements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ test {
 }
 
 application {
-    mainClass.set("duke.Duke")
+    mainClass.set("duke.Launcher")
 }
 
 shadowJar {
@@ -59,5 +59,6 @@ shadowJar {
 }
 
 run {
+    enableAssertions = true
     standardInput = System.in
 }

--- a/src/main/java/duke/lib/Storage.java
+++ b/src/main/java/duke/lib/Storage.java
@@ -16,9 +16,9 @@ import duke.task.TaskList;
  */
 public class Storage {
 
-    private File saveFile;
-    private String directoryPath;
-    private String fullFilePath;
+    private final File saveFile;
+    private final String directoryPath;
+    private final String fullFilePath;
 
     /**
      * Constructs a Storage object with the specified directory and file name.

--- a/src/main/java/duke/parser/Parser.java
+++ b/src/main/java/duke/parser/Parser.java
@@ -38,6 +38,7 @@ public class Parser {
                 throwException("The task index of a task cannot be empty", "delete <task index>");
             }
             int index = Validate.validateNumber(tokens[1]);
+            assert index >= 0 : "Index should be non-negative";
             return new DeleteCommand(index);
         }
         case "mark": {
@@ -45,6 +46,7 @@ public class Parser {
                 throwException("The task index of a task cannot be empty", "mark <task index>");
             }
             int index = Validate.validateNumber(tokens[1]);
+            assert index >= 0 : "Index should be non-negative";
             return new MarkCommand(index);
         }
         case "unmark": {
@@ -52,6 +54,7 @@ public class Parser {
                 throwException("The task index of a task cannot be empty", "unmark <task index>");
             }
             int index = Validate.validateNumber(tokens[1]);
+            assert index >= 0 : "Index should be non-negative";
             return new UnmarkCommand(index);
 
         }

--- a/src/main/java/duke/ui/DialogBox.java
+++ b/src/main/java/duke/ui/DialogBox.java
@@ -36,6 +36,9 @@ public class DialogBox extends HBox {
             fxmlLoader.setController(this);
             fxmlLoader.setRoot(this);
             fxmlLoader.load();
+
+            assert dialog != null : "Dialog Label is not initialized";
+            assert displayPicture != null : "Display Picture ImageView is not initialized";
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/duke/ui/MainWindow.java
+++ b/src/main/java/duke/ui/MainWindow.java
@@ -28,8 +28,8 @@ public class MainWindow extends AnchorPane {
 
     private Duke duke;
 
-    private Image userImage = new Image(this.getClass().getResourceAsStream("/images/user.png"));
-    private Image dukeImage = new Image(this.getClass().getResourceAsStream("/images/duke.png"));
+    private Image userImage;
+    private Image dukeImage;
 
     /**
      * Initializes the MainWindow. Binds the ScrollPane's vertical value to the height of the dialog container, ensuring
@@ -37,6 +37,19 @@ public class MainWindow extends AnchorPane {
      */
     @FXML
     public void initialize() {
+        assert scrollPane != null : "ScrollPane is not initialized";
+        assert dialogContainer != null : "DialogContainer is not initialized";
+        assert userInput != null : "UserInput is not initialized";
+        assert sendButton != null : "SendButton is not initialized";
+
+        java.io.InputStream userImagePath = this.getClass().getResourceAsStream("/images/user.png");
+        assert userImagePath != null : "UserImage could not be loaded";
+        userImage = new Image(userImagePath);
+
+        java.io.InputStream dukeImagePath = this.getClass().getResourceAsStream("/images/duke.png");
+        assert dukeImagePath != null : "DukeImage could not be loaded";
+        dukeImage = new Image(dukeImagePath);
+
         scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());
     }
 


### PR DESCRIPTION
Assumptions is made about UI elements being present at runtime.

However this might not always be the case and missing UI elements might lead to unexpected behavior.

Assertions let us catch these missing UI elements and stop execution.

Assertions can easily be disabled for production and ensure correct functionality where expected.

Refer to this for assertions reference:
https://nus-cs2103-ay2324s1.github.io/website/se-book-adapted/chapters/errorHandling.html#assertions