### PR TITLE
Add missing javadocs

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -41,6 +41,9 @@ public class Duke {
         return ui.getStatus();
     }
 
+    /**
+     * Gets the exit status of Duke.
+     */
     public boolean getExitStatus() {
         return hasExited;
     }

--- a/src/main/java/duke/Launcher.java
+++ b/src/main/java/duke/Launcher.java
@@ -6,6 +6,11 @@ import javafx.application.Application;
  * A launcher class to workaround classpath issues.
  */
 public class Launcher {
+    /**
+     * The main entry point for the application.
+     *
+     * @param args The command-line arguments passed to the application.
+     */
     public static void main(String[] args) {
         Application.launch(Main.class, args);
     }

--- a/src/main/java/duke/Main.java
+++ b/src/main/java/duke/Main.java
@@ -13,8 +13,7 @@ import javafx.stage.Stage;
  * A GUI for Duke using FXML.
  */
 public class Main extends Application {
-
-    private Duke duke = new Duke();
+    private final Duke duke = new Duke();
 
     @Override
     public void start(Stage stage) {

--- a/src/main/java/duke/lib/Storage.java
+++ b/src/main/java/duke/lib/Storage.java
@@ -38,7 +38,7 @@ public class Storage {
      *
      * @throws DukeException If an unexpected error occurs while creating the directory or file.
      */
-    private void createIfMissing() throws DukeException {
+    private void createMissingSaveFiles() throws DukeException {
         try {
             File directory = new File(this.directoryPath);
             if (!directory.exists()) {
@@ -67,7 +67,7 @@ public class Storage {
             }
             saveFileReader.close();
         } catch (FileNotFoundException e1) {
-            this.createIfMissing();
+            this.createMissingSaveFiles();
         } catch (Exception e) {
             throw new DukeException("File save is corrupted");
         }

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -11,17 +11,17 @@ public class Deadline extends Task {
     /**
      * Due date of the deadline task.
      */
-    protected LocalDateTime by;
+    protected LocalDateTime dueDate;
 
     /**
      * Constructs a Deadline object with the given description and due date.
      *
      * @param description Description of the deadline task.
-     * @param by          Due date of the task.
+     * @param dueDate     Due date of the task.
      */
-    public Deadline(String description, LocalDateTime by) {
+    public Deadline(String description, LocalDateTime dueDate) {
         super(description);
-        this.by = by;
+        this.dueDate = dueDate;
     }
 
     /**
@@ -31,7 +31,7 @@ public class Deadline extends Task {
      */
     @Override
     public String toString() {
-        return "[D]" + super.toString() + " (by: " + formatLocalDateTime(by) + ")";
+        return "[D]" + super.toString() + " (by: " + formatLocalDateTime(dueDate) + ")";
     }
 
     /**
@@ -41,6 +41,6 @@ public class Deadline extends Task {
      */
     @Override
     public String serialize() {
-        return String.format("D | %d | %s | %s", isDone ? 1 : 0, description, serializeLocalDateTime(by));
+        return String.format("D | %d | %s | %s", isDone ? 1 : 0, description, serializeLocalDateTime(dueDate));
     }
 }

--- a/src/main/java/duke/ui/MainWindow.java
+++ b/src/main/java/duke/ui/MainWindow.java
@@ -1,8 +1,5 @@
 package duke.ui;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-
 import duke.Duke;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
@@ -75,7 +72,7 @@ public class MainWindow extends AnchorPane {
         String response = duke.getResponse(input);
 
         if (duke.getExitStatus()) {
-            CompletableFuture.delayedExecutor(2, TimeUnit.SECONDS).execute(() -> Platform.exit());
+            setTimeout(Platform::exit, 1000);
         }
 
         dialogContainer.getChildren().addAll(
@@ -85,6 +82,12 @@ public class MainWindow extends AnchorPane {
         userInput.clear();
     }
 
+    /**
+     * Sets a timeout for executing a Runnable after a specified delay.
+     *
+     * @param runnable The code to be executed after the delay.
+     * @param delay    The delay in milliseconds before executing the Runnable.
+     */
     public static void setTimeout(Runnable runnable, int delay) {
         new Thread(() -> {
             try {


### PR DESCRIPTION
Missing javadocs can hurt the readability of the code for future readers as they might be unable to understand what the function does or requires.

Adding missing headers to all public classes and methods helps us to increase code readiblity and maintainability.